### PR TITLE
Mutate plugin setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     container_name: filebeat
     depends_on:
       - elasticsearch
+      - logstash
     volumes:
       - filebeat:/usr/share/filebeat/data
       - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
@@ -48,6 +49,15 @@ services:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     ports:
       - 5601:5601
+  logstash:
+    image: docker.elastic.co/logstash/logstash-oss:7.8.0
+    ports:
+      - '5044:5044'
+    container_name: logstash
+    volumes:
+      - ./logstash/pipeline/:/usr/share/logstash/pipeline/
+    depends_on:
+      - elasticsearch
   redis:
     image: redis:5.0.8
     container_name: 'think-micro-redis'

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -13,5 +13,5 @@ setup:
   kibana:
     host: "http://kibana:5601"
 output:
-  elasticsearch:
-    hosts: ["http://elasticsearch:9200"]
+  logstash:
+    hosts: ["logstash:5044"]

--- a/logstash/pipeline/filebeat.config
+++ b/logstash/pipeline/filebeat.config
@@ -1,0 +1,21 @@
+input {
+  beats {
+    port => 5044
+    host => "0.0.0.0"
+  }
+}
+filter {
+  mutate {
+    gsub => [
+      "msg", "\"uuid\" = '.*'", "'uuid' = 'redacted'",
+      "token", ".+", "token_granted"
+    ]
+  }
+}
+output {
+  elasticsearch {
+    hosts => "http://elasticsearch:9200"
+    manage_template => false
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
+  }
+}


### PR DESCRIPTION
В рамках данного пул реквеста был реализован следующий функционал:
1) Теперь filebeat отдает данные в logstash, после чего данные преобразуются и отправляются в elasticsearch;
2) В logstash был использован plugin mutate (gsub) для замены чувствительной информации в логах;
3) Теперь токен и uuid пользователя пользователя обфусцируются